### PR TITLE
Use consistent python version in test, docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 # borrowed from the docker example: https://docs.docker.com/compose/django/
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
The CircleCI config uses a Python 3.6 docker image, so we should also be sure to use Python 3.6 when we build the docker image to deploy.